### PR TITLE
add `no-push` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,13 @@
 
 A gem to bump versions of cocoa pods podspec.
 
- - bumps version major / minor / patch
- - commit changes
- - added tag
- - push to specs repository
- 
+- bumps version major / minor / patch
+- commit changes
+- added tag
+- push to specs repository
+
 # Installation
- 
+
 ```
 gem install pod-bump
 ```
@@ -32,7 +32,7 @@ pod-bump patch # Bump version 0.0.0 to 0.0.1
 ### Set (version)
 
 ```
-pod-bump set 1.2.3 # Set version to 1.2.3  
+pod-bump set 1.2.3 # Set version to 1.2.3
 ```
 
 Note: Version should pass semantic validation. See https://semver.org/
@@ -68,7 +68,15 @@ pod-bump patch --m "Additional info"
 Do not commit and push to podspec after podspec version bump.
 
 ```
-pob-bump major --no-commit
+pod-bump major --no-commit
+```
+
+### `--no-push`
+
+Do not push to podspec after podspec version bump.
+
+```
+pod-bump major --no-push
 ```
 
 ### `--version`

--- a/bin/pod-bump
+++ b/bin/pod-bump
@@ -18,6 +18,7 @@ OptionParser.new do |opt|
   opt.on("-s", "--specs_repository [REPO_URL]", "Specs repository to push. Default 'trunk'.") { |o| options[:spec_repository] = o }
   opt.on("-m", "--commit-message [MSG]", "Commit message. Default 'Bumped Version [Vesion]' ") { |o| options[:commit_message] = o }
   opt.on("--no-commit", "Do not commit after version bump") { options[:no_commit] = true }
+  opt.on("--no-push", "Do not push after version bump") { options[:no_push] = true }
   opt.on("--version", "Print current version") { options[:print_version] = true }
 end.parse!
 

--- a/lib/pod-bump.rb
+++ b/lib/pod-bump.rb
@@ -61,7 +61,7 @@ module PodBump
           return result
         end
       end
-      
+
       command = "pod repo push " + specs_repository_name + " " + podspec_name
       puts "Running " + command
       result = system(command)
@@ -74,7 +74,7 @@ module PodBump
     if result == false
       puts "Could not update podspec please do it manually after fixing errors"
     end
-    
+
     return result
   end
 
@@ -103,7 +103,7 @@ module PodBump
     for line in lines
       prefix_count_of_spaces = line.size - line.lstrip.size
       version_line_part = line.match(/\.version\s*=\s*["']#{VERSION_REGEX}["']/).to_s
-      
+
       if version_line_part.empty? == false
         items = line.split(' ')
         previous_version_string = items[2]
@@ -123,7 +123,7 @@ module PodBump
       end
       output_file.close()
     end
-    
+
     return updated
   end
 
@@ -175,7 +175,7 @@ module PodBump
       puts "Version to set should use valid semantic versioning"
       return
     end
-     
+
     podspec_file_path = find_podspec_in_current_folder
     if podspec_file_path == nil
       puts "No podspec file found in current directory"
@@ -205,15 +205,20 @@ module PodBump
       return
     end
 
-    puts "Updated version in podspec " + podspec_file_path 
-  
+    puts "Updated version in podspec " + podspec_file_path
+
     if options[:no_commit] == true
       return
     end
-    
+
     commit_git_repo = commit_git_repo(podspec_file_path, options[:commit_message], version_to_update)
     if commit_git_repo == false
       puts "Could not commit to git repo"
+      return
+    end
+
+    if options[:no_push] == true
+      puts "Successfully bumped version to " + version_to_update
       return
     end
 


### PR DESCRIPTION
hello, @kitaisreal 👋
thanks a lot for making this tool 🙏 
I needed this option to `commit`, but run the `trunk push` flow on the CI for tagged commits.
I hope it sounds reasonable.
thanks!

---

**ps:** I'm using `prettier` and `trim-empty-spaces` stuff on my editor, irrelevant-ish updates are made automatically, can revert if needed. 😊 

